### PR TITLE
add Block Counter, improve block data handling, and update sandbox toolbar

### DIFF
--- a/src/feature/sandbox/components/Block/index.tsx
+++ b/src/feature/sandbox/components/Block/index.tsx
@@ -1,40 +1,50 @@
 import { useTexture } from "@react-three/drei";
 import type { ThreeEvent } from "@react-three/fiber";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import * as THREE from "three";
 import { listBlockIdWithHeight90Percent } from "../../data/blockNotFull";
-import type { ItemType } from "../../data/ItemList";
+import { ItemList } from "../../data/ItemList";
+
+export type BlockProperties = {
+  x: number;
+  y: number;
+  z: number;
+  blockId: string;
+};
 
 function SandboxBlock({
   block,
   handleClick,
 }: {
-  block: { x: number; y: number; z: number; block: ItemType };
+  block: BlockProperties;
   handleClick: (
     data: ThreeEvent<MouseEvent>,
     position: { x: number; y: number; z: number }
   ) => void;
 }) {
+  const blockData = useMemo(
+    () => ItemList.find((item) => item.id === block.blockId),
+    [block.blockId]
+  );
+
   const blockId = `block-${block.x}-${block.y}-${block.z}`;
 
   const defaultTexture = "/images/textures/blocks/dirt.png";
   const fallbackTexture = "/images/textures/blocks/barrier.png";
 
   const isBlockHeight90Percent = listBlockIdWithHeight90Percent.find(
-    (id: string) => id === block.block.id
+    (id: string) => id === blockData?.id
   );
 
-  const mainTexture = block.block.texture
-    ? `/images/textures/blocks/${block.block.texture}.png`
+  const mainTexture = blockData?.texture ? `/images/textures/blocks/${blockData?.texture}.png` : "";
+  const sideTexture = blockData?.sideTexture
+    ? `/images/textures/blocks/${blockData?.sideTexture}.png`
     : "";
-  const sideTexture = block.block.sideTexture
-    ? `/images/textures/blocks/${block.block.sideTexture}.png`
+  const topTexture = blockData?.topTexture
+    ? `/images/textures/blocks/${blockData?.topTexture}.png`
     : "";
-  const topTexture = block.block.topTexture
-    ? `/images/textures/blocks/${block.block.topTexture}.png`
-    : "";
-  const bottomTexture = block.block.bottomTexture
-    ? `/images/textures/blocks/${block.block.bottomTexture}.png`
+  const bottomTexture = blockData?.bottomTexture
+    ? `/images/textures/blocks/${blockData?.bottomTexture}.png`
     : "";
 
   const [finalMain, setFinalMain] = useState(defaultTexture);
@@ -53,7 +63,7 @@ function SandboxBlock({
   }
 
   let materials: THREE.Material[];
-  if (block.block.texture) {
+  if (blockData?.texture) {
     const mainTex = useTexture(
       finalMain
       // { fallback: fallbackTexture }
@@ -79,7 +89,7 @@ function SandboxBlock({
   useEffect(() => {
     let mounted = true;
     async function fetchTextures() {
-      if (block.block.texture) {
+      if (blockData?.texture) {
         const main = await checkImage(mainTexture, fallbackTexture);
         if (mounted) setFinalMain(main);
       } else {
@@ -97,12 +107,7 @@ function SandboxBlock({
     return () => {
       mounted = false;
     };
-  }, [
-    block.block.texture,
-    block.block.sideTexture,
-    block.block.topTexture,
-    block.block.bottomTexture,
-  ]);
+  }, [blockData?.texture, blockData?.sideTexture, blockData?.topTexture, blockData?.bottomTexture]);
 
   return (
     <group
@@ -114,12 +119,12 @@ function SandboxBlock({
         material={materials}
         position={[
           0,
-          isBlockHeight90Percent ? (block.block.id === "120" ? -0.09375 : -0.035) : 0,
+          isBlockHeight90Percent ? (blockData?.id === "120" ? -0.09375 : -0.035) : 0,
           0,
         ]}
       >
         <boxGeometry
-          args={[1, isBlockHeight90Percent ? (block.block.id === "120" ? 0.8125 : 0.93) : 1, 1]}
+          args={[1, isBlockHeight90Percent ? (blockData?.id === "120" ? 0.8125 : 0.93) : 1, 1]}
         />
       </mesh>
 

--- a/src/feature/sandbox/components/Toolbar/index.tsx
+++ b/src/feature/sandbox/components/Toolbar/index.tsx
@@ -6,8 +6,10 @@ import { Button, Modal } from "antd";
 import { useAtom } from "jotai";
 import { useEffect, useState } from "react";
 import { AiOutlineTable } from "react-icons/ai";
+import { MdNumbers } from "react-icons/md";
 import { ItemList, type ItemType } from "../../data/ItemList";
 import { activeToolbarIndex, listToolbarItems, selectedBlock } from "../../store";
+import SandboxTotalBlockRequired from "../TotalBlockRequired";
 
 // Local Components
 type ToolbarProps = {
@@ -38,6 +40,7 @@ const Toolbar = ({ listToolbar, activeToolbar, setActiveToolbar }: ToolbarProps)
 // Main Component
 function SandboxToolbar() {
   const [showNodalItems, setShowModalItems] = useState(false);
+  const [showModalTotalBlockRequired, setShowModalTotalBlockRequired] = useState(false);
 
   const [_, setSelectedBlock] = useAtom(selectedBlock);
   const [activeToolbar, setActiveToolbar] = useAtom(activeToolbarIndex);
@@ -52,12 +55,12 @@ function SandboxToolbar() {
       <div className="absolute w-screen bottom-4">
         <div className="w-full z-10 flex justify-center gap-0.5">
           <Button
-            className="!w-[50px] !h-[50px] text-xl font-bold mr-4 invisible"
+            className="!w-[50px] !h-[50px] text-xl font-bold mr-4"
             onClick={() => {
-              setShowModalItems(true);
+              setShowModalTotalBlockRequired(true);
             }}
           >
-            +
+            <MdNumbers size={32} />
           </Button>
           <Toolbar
             listToolbar={listToolbar}
@@ -75,6 +78,7 @@ function SandboxToolbar() {
         </div>
       </div>
 
+      {/* Inventory Modal */}
       <Modal
         open={showNodalItems}
         onCancel={() => setShowModalItems(false)}
@@ -110,6 +114,20 @@ function SandboxToolbar() {
             activeToolbar={activeToolbar}
             setActiveToolbar={setActiveToolbar}
           />
+        </div>
+      </Modal>
+
+      {/* Total Block Required */}
+      <Modal
+        open={showModalTotalBlockRequired}
+        onCancel={() => setShowModalTotalBlockRequired(false)}
+        centered
+        closable={false}
+        footer={null}
+        className="!w-auto !min-w-0"
+      >
+        <div className="overflow-auto max-h-[80vh] max-w-[500px]">
+          <SandboxTotalBlockRequired />
         </div>
       </Modal>
     </>

--- a/src/feature/sandbox/components/TotalBlockRequired/index.tsx
+++ b/src/feature/sandbox/components/TotalBlockRequired/index.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Table, type TableColumnsType } from "antd";
+import { useAtom } from "jotai";
+import { ItemList } from "../../data/ItemList";
+import { blocksPlaced } from "../../store";
+import type { BlockProperties } from "../Block";
+
+function getTotalBlocksById(blocks: BlockProperties[]) {
+  return blocks.reduce(
+    (result, { blockId }) => {
+      result[blockId] = (result[blockId] || 0) + 1;
+      return result;
+    },
+    {} as Record<string, number>
+  );
+}
+
+function SandboxTotalBlockRequired() {
+  const [blockList] = useAtom<BlockProperties[]>(blocksPlaced);
+
+  const blockCounter = getTotalBlocksById(blockList);
+
+  const data = Object.entries(blockCounter).map(([id, total]) => {
+    const blockData = ItemList.find((item) => item.id === id);
+
+    return {
+      id,
+      total,
+      name: blockData?.name,
+      sprite: blockData?.spritePosition,
+    };
+  });
+
+  const columns: TableColumnsType = [
+    {
+      title: "Block",
+      dataIndex: "sprite",
+      key: "sprite",
+      render: (text: string) => <div className={`items-${text} w-[32px] h-[32px]`} />,
+      width: 100,
+    },
+    {
+      title: "Name",
+      dataIndex: "name",
+      key: "name",
+    },
+    {
+      title: "Total Block",
+      dataIndex: "total",
+      key: "total",
+    },
+    {
+      title: "Total Stack",
+      dataIndex: "total",
+      key: "total-stack",
+      render: (text: number) => {
+        const stackCounter = Math.floor(text / 64);
+        const remainingBlock = text % 64;
+
+        return (
+          <div>
+            {stackCounter > 0 && <>{stackCounter} Stack</>}{" "}
+            {remainingBlock > 0 && <>{remainingBlock} Block</>}
+          </div>
+        );
+      },
+    },
+  ];
+
+  return <Table dataSource={data} columns={columns} pagination={false} sticky />;
+}
+
+export default SandboxTotalBlockRequired;

--- a/src/feature/sandbox/page/index.tsx
+++ b/src/feature/sandbox/page/index.tsx
@@ -8,8 +8,7 @@ import { useState } from "react";
 import SandboxBlock from "../components/Block";
 import SandboxContextMenu from "../components/ContextMenu";
 import SandboxToolbar from "../components/Toolbar";
-import type { ItemType } from "../data/ItemList";
-import { selectedBlock } from "../store";
+import { blocksPlaced, selectedBlock } from "../store";
 
 function SandboxIndex() {
   const [api, contextHolder] = notification.useNotification();
@@ -20,23 +19,20 @@ function SandboxIndex() {
 
   const [selectedBlockLocale] = useAtom(selectedBlock);
 
-  const initialBlockList: { x: number; y: number; z: number; block: ItemType }[] = [
+  const initialBlockList: {
+    x: number;
+    y: number;
+    z: number;
+    blockId: string;
+  }[] = [
     {
       x: 0,
       y: 0,
       z: 0,
-      block: {
-        id: "2",
-        spritePosition: "28-2-0",
-        name: "Grass",
-        textId: "(minecraft:grass)",
-        sideTexture: "grass_side_carried",
-        topTexture: "grass_carried",
-        bottomTexture: "dirt",
-      },
+      blockId: "2",
     },
   ];
-  const [blockList, setBlockList] = useState(initialBlockList);
+  const [blockList, setBlockList] = useAtom(blocksPlaced);
 
   const handleClick = (
     data: ThreeEvent<MouseEvent>,
@@ -76,7 +72,7 @@ function SandboxIndex() {
         }
       }
 
-      setBlockList((prev) => [...prev, { ...newBlockPosition, block: selectedBlockLocale }]);
+      setBlockList((prev) => [...prev, { ...newBlockPosition, blockId: selectedBlockLocale.id }]);
     }
 
     if (mode === "remove") {

--- a/src/feature/sandbox/store/index.tsx
+++ b/src/feature/sandbox/store/index.tsx
@@ -1,10 +1,19 @@
 import { atom } from "jotai";
+import type { BlockProperties } from "../components/Block";
 import { ItemList } from "../data/ItemList";
 
 // Only for testing purpose
 // reset value to 0 if you want to deploy
 const multiply = 0;
 
+export const blocksPlaced = atom<BlockProperties[]>([
+  {
+    x: 0,
+    y: 0,
+    z: 0,
+    blockId: "2",
+  },
+]);
 export const selectedBlock = atom(ItemList[1]);
 export const activeToolbarIndex = atom(0);
 export const listToolbarItems = atom(ItemList.slice(0 + 9 * multiply, 9 + 9 * multiply));


### PR DESCRIPTION
- Refactor block data management to store only block IDs in the block list
- Automatically apply blueprint changes to all relevant blocks
- Add Block Counter to sandbox toolbar for quick block usage overview
- Display block sprite, name, total count, stack total, and remaining blocks after stacking